### PR TITLE
[install] Add support for KDE Plasma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change the user account name from "stick" to "winesap".
 - Add support for installing Arch Linux.
 - Change the office suite from FreeOffice to LibreOffice.
+- Add support for installing the KDE Plasma desktop environment.
 
 ## 2.2.0
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -60,6 +60,7 @@ $ export <KEY>=<VALUE>
 | --- | ------ | ------------- | ----------- |
 | WINESAPOS_DEBUG | true or false | false | Use `set -x` for debug shell logging. |
 | WINESAPOS_DISTRO | arch or manjaro | arch | The Linux distribution to install with. |
+| WINESAPOS_DE | cinnamon or kde | kde | The desktop environment to install. |
 | WINESAPOS_DEVICE | | vda | The `/dev/${WINESAPOS_DEVICE}` storage device to install winesapOS onto. |
 | WINESAPOS_ENCRYPT | true or false | false | If the root partition should be encrypted with LUKS. |
 | WINESAPOS_ENCRYPT_PASSWORD | | password | The default password for the encrypted root partition. |

--- a/scripts/winesapos-install.sh
+++ b/scripts/winesapos-install.sh
@@ -9,6 +9,7 @@ exec > >(tee /tmp/winesapos-install.log) 2>&1
 echo "Start time: $(date)"
 
 WINESAPOS_DISTRO="${WINESAPOS_DISTRO:-arch}"
+WINESAPOS_DE="${WINESAPOS_DE:-kde}"
 WINESAPOS_ENCRYPT="${WINESAPOS_ENCRYPT:-false}"
 WINESAPOS_ENCRYPT_PASSWORD="${WINESAPOS_ENCRYPT_PASSWORD:-password}"
 WINESAPOS_CPU_MITIGATIONS="${WINESAPOS_CPU_MITIGATIONS:-false}"
@@ -296,7 +297,7 @@ arch-chroot /mnt sudo -u winesap ge-install-manager -i Proton-6.5-GE-2
 rm -f /mnt/home/winesap/.local/share/Steam/compatibilitytools.d/Proton-*.tar.gz
 echo "Installing gaming tools complete."
 
-echo "Setting up the Cinnamon desktop environment..."
+echo "Setting up the desktop environment..."
 # Install Xorg.
 arch-chroot /mnt ${CMD_PACMAN_INSTALL} xorg-server lib32-mesa mesa xorg-server xorg-xinit xterm xf86-input-libinput xf86-video-amdgpu xf86-video-intel xf86-video-nouveau
 # Install Light Display Manager.
@@ -306,14 +307,34 @@ if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
 else
     arch-chroot /mnt sudo -u winesap yay --noconfirm -S lightdm-settings
 fi
-# Install Cinnamon.
-if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
-    arch-chroot /mnt ${CMD_PACMAN_INSTALL} cinnamon cinnamon-sounds cinnamon-wallpapers manjaro-cinnamon-settings manjaro-settings-manager
-    # Install Manjaro specific Cinnamon theme packages.
-    arch-chroot /mnt ${CMD_PACMAN_INSTALL} adapta-maia-theme kvantum-manjaro
-else
-    arch-chroot /mnt ${CMD_PACMAN_INSTALL} cinnamon
+
+if [[ "${WINESAPOS_DE}" == "cinnamon" ]]; then
+    echo "Installing the Cinnamon desktop environment..."
+
+    if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
+        arch-chroot /mnt ${CMD_PACMAN_INSTALL} cinnamon cinnamon-sounds cinnamon-wallpapers manjaro-cinnamon-settings manjaro-settings-manager
+        # Install Manjaro specific Cinnamon theme packages.
+        arch-chroot /mnt ${CMD_PACMAN_INSTALL} adapta-maia-theme kvantum-manjaro
+    else
+        arch-chroot /mnt ${CMD_PACMAN_INSTALL} cinnamon
+    fi
+
+    echo "Installing the Cinnamon desktop environment complete."
+elif [[ "${WINESAPOS_DE}" == "kde" ]]; then
+    echo "Installing the KDE Plasma desktop environment..."
+    # Clean up the Pacman cache to free up enough storage to install KDE Plasma.
+    arch-chroot /mnt pacman --noconfirm -S -c -c
+    arch-chroot /mnt ${CMD_PACMAN_INSTALL} plasma-meta kde-applications-meta plasma-nm kio-extras
+
+    if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
+        arch-chroot /mnt ${CMD_PACMAN_INSTALL} manjaro-kde-settings manjaro-settings-manager-kcm manjaro-settings-manager-knotifier
+        # Install Manjaro specific KDE Plasma theme packages.
+        arch-chroot /mnt ${CMD_PACMAN_INSTALL} breath-icon-theme breath-wallpapers plasma5-themes-breath sddm-breath-theme
+    fi
+
+    echo "Installing the KDE Plasma desktop environment complete."
 fi
+
 # Start LightDM. This will provide an option of which desktop environment to load.
 arch-chroot /mnt systemctl enable lightdm
 # Install Bluetooth.
@@ -340,7 +361,7 @@ chown -R 1000.1000 /mnt/home/winesap/.config
 # Install printer drivers.
 arch-chroot /mnt ${CMD_PACMAN_INSTALL} cups libcups lib32-libcups bluez-cups cups-pdf usbutils
 arch-chroot /mnt systemctl enable cups
-echo "Setting up the Cinnamon desktop environment complete."
+echo "Setting up the desktop environment complete."
 
 echo "Setting up desktop shortcuts..."
 mkdir /mnt/home/winesap/Desktop

--- a/scripts/winesapos-tests.sh
+++ b/scripts/winesapos-tests.sh
@@ -9,6 +9,7 @@ echo "Tests start time: $(date)"
 DEVICE_SHORT="${WINESAPOS_DEVICE:-vda}"
 DEVICE_FULL="/dev/${DEVICE_SHORT}"
 WINESAPOS_DISTRO="${WINESAPOS_DISTRO:-arch}"
+WINESAPOS_DE="${WINESAPOS_DE:-kde}"
 
 echo "Testing partitions..."
 lsblk_f_output=$(lsblk -f)
@@ -190,7 +191,28 @@ else
 fi
 
 echo "Checking that the Cinnamon desktop environment packages are installed..."
-pacman_search_loop blueberry cinnamon lightdm xorg-server
+if [[ "${WINESAPOS_DE}" == "cinnamon" ]]; then
+    pacman_search_loop blueberry cinnamon lightdm xorg-server
+    if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
+        pacman_search_loop \
+            cinnamon-sounds \
+            cinnamon-wallpapers \
+            manjaro-cinnamon-settings \
+            manjaro-settings-manager$ \
+            adapta-maia-theme \
+            kvantum-manjaro
+    fi
+elif [[ "${WINESAPOS_DE}" == "kde" ]]; then
+    pacman_search_loop plasma-meta kde-applications-meta plasma-nm kio-extras
+    if [[ "${WINESAPOS_DISTRO}" == "manjaro" ]]; then
+        pacman_search_loop \
+            manjaro-kde-settings \
+            manjaro-settings-manager-kcm \
+            manjaro-settings-manager-knotifier \
+            breath-icon-theme breath-wallpapers \
+            plasma5-themes-breath sddm-breath-theme
+    fi
+fi
 
 echo -n "Testing package installations complete.\n\n"
 


### PR DESCRIPTION
This desktop environment will now be the default instead of Cinnamon
to further align with SteamOS 3.

Add additional tests for extra packages for Cinnamon and KDE.

Resolves #106