### PR TITLE
[install] Do not install 'tlp'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for installing the KDE Plasma desktop environment.
 - Add LTS Linux kernel 5.15.
 - Add MultiMC for playing Minecraft.
+- Remove TLP. This power management utility conflicts with auto-cpufreq.
 
 ## 2.2.0
 

--- a/scripts/winesapos-install.sh
+++ b/scripts/winesapos-install.sh
@@ -254,10 +254,7 @@ echo "Installing the Linux kernels complete."
 
 echo "Optimizing battery life..."
 arch-chroot /mnt sudo -u winesap yay --noconfirm -S auto-cpufreq
-# This service is masked by default and cannot be managed until unmasked.
-arch-chroot /mnt systemctl unmask auto-cpufreq
-arch-chroot /mnt ${CMD_PACMAN_INSTALL} tlp
-arch-chroot /mnt systemctl enable auto-cpufreq tlp
+arch-chroot /mnt systemctl enable auto-cpufreq
 echo "Optimizing battery life complete."
 
 echo "Enabling 32-bit multlib libraries..."

--- a/scripts/winesapos-tests.sh
+++ b/scripts/winesapos-tests.sh
@@ -267,7 +267,6 @@ for i in \
   snapper-cleanup.timer \
   snapper-timeline.timer \
   systemd-timesyncd \
-  tlp \
   touch-bar-usbmuxd-fix
     do echo -n "\t${i}..."
     arch-chroot /mnt systemctl --quiet is-enabled ${i}


### PR DESCRIPTION
This package conflicts with 'auto-cpufreq'.

Resolves #165