### PR TITLE
feat: Allow user to select a mirror country

### DIFF
--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -74,22 +74,18 @@ chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
                         --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" \
                         "${arch_mirror_regions[@]}")
 
-# Append the region to /etc/xdg/reflector/reflector.conf (--country C1,C2,C3) if a region was chosen
-if [ -n "${chosen_region}" ]; then
-    echo "Chosen region: ${chosen_region}"
-    echo "--country '${chosen_region}'" | sudo tee -a /etc/xdg/reflector/reflector.conf
-fi
-
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)
 if [ "${os_detected}" = "arch" ] || [ "${os_detected}" = "steamos" ]; then
     # Check if the user seelcted a mirror region.
     if [ -n "${chosen_region}" ]; then 
-        sudo systemctl start reflector.service
+        sudo reflector --verbose --latest 10 --sort age --save /etc/pacman.d/mirrorlist --country "${chosen_region}"
+        # this seems like a better idea than writing global config we can't reliably remove a line
     else
         # Fallback to the Arch global mirror
         echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch' | sudo tee /etc/pacman.d/mirrorlist
     fi
 fi
+
 if [[ "${os_detected}" == "manjaro" ]]; then
     sudo systemctl start pacman-mirrors.service
 fi

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -75,7 +75,7 @@ fi
 
 if [ "${os_detected}" = "manjaro" ]; then
     # Fetch the list of regions from the Manjaro mirror status JSON API
-    mirror_regions=("${(@f)$(curl -s https://repo.manjaro.org/status.json | jq -r '.urls[].country' | sort | uniq)}")
+    mirror_regions=("${(@f)$(curl -s https://repo.manjaro.org/status.json | jq -r '.[].country' | sort | uniq)}")
 fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -75,7 +75,7 @@ fi
 
 if [ "${os_detected}" = "manjaro" ]; then
     # Fetch the list of regions from the Manjaro mirror status JSON API
-    mirror_regions=("${(@f)$(curl -s https://repo.manjaro.org/status.json | jq -r '.urls[].country' | sort | uniq | sed '1d')}")
+    mirror_regions=("${(@f)$(curl -s https://repo.manjaro.org/status.json | jq -r '.urls[].country' | sort | uniq)}")
 fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -80,7 +80,7 @@ fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)
 chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
-                        --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" \
+                        --combobox "Select your desired mirror region, \nor press Cancel to use a default mirror:" \
                         "${mirror_regions[@]}")
 
 qdbus ${kdialog_dbus} /ProgressDialog Set org.kde.kdialog.ProgressDialog value 1
@@ -97,10 +97,14 @@ if [ "${os_detected}" = "arch" ] || [ "${os_detected}" = "steamos" ]; then
 fi
 
 if [[ "${os_detected}" == "manjaro" ]]; then
-    sudo pacman-mirrors -c "${chosen_region}"
+    if [ -n "${chosen_region}" ]; then
+        sudo pacman-mirrors -c "${chosen_region}"
+    else
+        sudo pacman-mirrors -f 5
+    fi
 fi
 
-# Wait for the fast mirrors to be populated.
+# We're in control now so no need for sleep()
 qdbus ${kdialog_dbus} /ProgressDialog Set org.kde.kdialog.ProgressDialog value 2
 
 sudo pacman -S -y

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -69,14 +69,15 @@ echo "Turning on the Mac fan service if the hardware is Apple complete."
 
 # Dialog to ask the user what mirror region they want to use
 # Fetch the list of regions from the Arch Linux mirror status JSON API
-arch_mirror_regions=$(curl -s https://archlinux.org/mirrors/status/json/ | jq -r '.urls[].country_code' | sort | uniq)
+readarray -t arch_mirror_regions <<< $(curl -s https://archlinux.org/mirrors/status/json/ | jq -r '.urls[].country' | sort | uniq | sed '1d')
 chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
-                        --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" ${arch_mirror_regions})
+                        --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" \
+                        "${arch_mirror_regions[@]}")
 
 # Append the region to /etc/xdg/reflector/reflector.conf (--country C1,C2,C3) if a region was chosen
-if [ -n "${chosen_region}" ]; then
+if [[ -n "${chosen_region}" ] && [ "${chosen_region}" != "" ]]; then
     echo "Chosen region: ${chosen_region}"
-    echo "--country ${chosen_region}" | sudo tee -a /etc/xdg/reflector/reflector.conf
+    echo "--country '${chosen_region}'" | sudo tee -a /etc/xdg/reflector/reflector.conf
 fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -80,16 +80,17 @@ fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)
 chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
-                        --combobox "Select your desired mirror region, \nor press Cancel to use a default mirror:" \
+                        --combobox "Select your desired mirror region, \nor press Cancel to use default settings:" \
                         "${mirror_regions[@]}")
 
 qdbus ${kdialog_dbus} /ProgressDialog Set org.kde.kdialog.ProgressDialog value 1
 
 if [ "${os_detected}" = "arch" ] || [ "${os_detected}" = "steamos" ]; then
-    # Check if the user seelcted a mirror region.
+    # Check if the user selected a mirror region.
     if [ -n "${chosen_region}" ]; then 
-        sudo reflector --verbose --latest 10 --sort age --save /etc/pacman.d/mirrorlist --country "${chosen_region}"
         # this seems like a better idea than writing global config we can't reliably remove a line
+        sudo reflector --verbose --latest 10 --sort age --save /etc/pacman.d/mirrorlist --country "${chosen_region}"
+        # ideally we should be sorting by `rate` for consistency but it may get too slow
     else
         # Fallback to the Arch global mirror
         echo 'Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch' | sudo tee /etc/pacman.d/mirrorlist

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -69,7 +69,7 @@ echo "Turning on the Mac fan service if the hardware is Apple complete."
 
 # Dialog to ask the user what mirror region they want to use
 # Fetch the list of regions from the Arch Linux mirror status JSON API
-readarray -t arch_mirror_regions <<< $(curl -s https://archlinux.org/mirrors/status/json/ | jq -r '.urls[].country' | sort | uniq | sed '1d')
+arch_mirror_regions=("${(@f)$(curl -s https://archlinux.org/mirrors/status/json/ | jq -r '.urls[].country' | sort | uniq | sed '1d')}")
 chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
                         --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" \
                         "${arch_mirror_regions[@]}")

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -75,7 +75,7 @@ chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
                         "${arch_mirror_regions[@]}")
 
 # Append the region to /etc/xdg/reflector/reflector.conf (--country C1,C2,C3) if a region was chosen
-if [[ -n "${chosen_region}" ] && [ "${chosen_region}" != "" ]]; then
+if [[ -n "${chosen_region}" ]]; then
     echo "Chosen region: ${chosen_region}"
     echo "--country '${chosen_region}'" | sudo tee -a /etc/xdg/reflector/reflector.conf
 fi

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -77,7 +77,7 @@ chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
 # Append the region to /etc/xdg/reflector/reflector.conf (--country C1,C2,C3) if a region was chosen
 if [ -n "${chosen_region}" ]; then
     echo "Chosen region: ${chosen_region}"
-    echo "--country ${chosen_region}" >> /etc/xdg/reflector/reflector.conf
+    echo "--country ${chosen_region}" | sudo tee -a /etc/xdg/reflector/reflector.conf
 fi
 
 kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for the setup to update the Pacman cache..." 3 | cut -d" " -f1)

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -69,8 +69,7 @@ echo "Turning on the Mac fan service if the hardware is Apple complete."
 
 # Dialog to ask the user what mirror region they want to use
 # Fetch the list of regions from the Arch Linux mirror status JSON API
-arch_mirror_regions=$(curl -s https://archlinux.org/mirrors/status/json/ | \
-                        grep -oP '(?<="country_code": ")[^"]*' | sort | uniq) # grep maybe fragile, woule be better if we can use jq
+arch_mirror_regions=$(curl -s https://archlinux.org/mirrors/status/json/ | jq -r '.urls[].country_code' | sort | uniq)
 chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
                         --combobox "Select your desired mirror region, \nor press Cancel to use the Arch worldwide mirror:" ${arch_mirror_regions})
 

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -75,7 +75,7 @@ chosen_region=$(kdialog --title "winesapOS First-Time Setup" \
                         "${arch_mirror_regions[@]}")
 
 # Append the region to /etc/xdg/reflector/reflector.conf (--country C1,C2,C3) if a region was chosen
-if [[ -n "${chosen_region}" ]]; then
+if [ -n "${chosen_region}" ]; then
     echo "Chosen region: ${chosen_region}"
     echo "--country '${chosen_region}'" | sudo tee -a /etc/xdg/reflector/reflector.conf
 fi


### PR DESCRIPTION
Sorta a hack. Prevents a scenario where a recently synced but too distant mirror is chosen, leading to unbearable download speeds

It would be (slightly) better if we can use `jq` here to parse the JSON reply however
