### PR TITLE
feat[setup]: setup zram if user opted out of swap

### DIFF
--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -325,8 +325,8 @@ elif [ $? -eq 1 ]; then
         echo """#!/bin/bash
 
 /usr/bin/modprobe zram
-echo ${zram_size}M > /sys/block/zram0/disksize
 echo zstd > /sys/block/zram0/comp_algorithm
+echo ${zram_size}M > /sys/block/zram0/disksize
 /usr/bin/mkswap --label winesapos-zram /dev/zram0
 /usr/bin/swapon --priority 100 /dev/zram0""" | sudo tee /usr/local/bin/winesapos-zram-setup.sh && sudo chmod +x /usr/local/bin/winesapos-zram-setup.sh
 

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -340,7 +340,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/etc/winesapos/zram-setup.sh
+ExecStart=/usr/bin/bash /etc/winesapos/zram-setup.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/winesapos-setup.sh
+++ b/scripts/winesapos-setup.sh
@@ -309,6 +309,47 @@ if [ $? -eq 0 ]; then
     sudo swapon /swap/swapfile
     echo "/swap/swapfile    none    swap    defaults    0 0" | sudo tee -a /etc/fstab
     qdbus ${kdialog_dbus} /ProgressDialog org.kde.kdialog.ProgressDialog.close
+elif [ $? -eq 1 ]; then
+    # If the user does not want swap, ask them about zram instead.
+    kdialog --title "winesapOS First-Time Setup" --yesno "Do you want to setup zram instead (recommended if you don't use swap)?"
+    if [ $? -eq 0 ]; then
+        kdialog_dbus=$(kdialog --title "winesapOS First-Time Setup" --progressbar "Please wait for zram to be enabled..." 2 | cut -d" " -f1)
+        qdbus ${kdialog_dbus} /ProgressDialog Set org.kde.kdialog.ProgressDialog value 1
+        # zram half the size of RAM.
+        winesap_ram_size=$(free -m | grep Mem | awk '{print $2}')
+        zram_size=$(expr ${winesap_ram_size} / 2)
+        sudo touch /etc/systemd/system/winesap-zram.service /etc/winesapos/zram-setup.sh
+        
+        # Setup script to run on boot.
+        # Yes they are supposed to not be tabbed in.
+        echo """
+#!/bin/bash
+
+/usr/bin/modprobe zram
+echo ${zram_size}M > /sys/block/zram0/disksize
+echo zstd > /sys/block/zram0/comp_algorithm
+/usr/bin/mkswap --label winesapos-zram /dev/zram0
+/usr/bin/swapon --priority 100 /dev/zram0
+        """ | sudo tee /etc/winesapos/zram-setup.sh && sudo chmod +x /etc/winesapos/zram-setup.sh
+
+        # Now the systemd service.
+        echo """
+[Unit]
+Description=WinesapOS zram setup
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/etc/winesapos/zram-setup.sh
+
+[Install]
+WantedBy=multi-user.target
+        """ | sudo tee /etc/systemd/system/winesap-zram.service
+
+        sudo systemctl daemon-reload && sudo systemctl enable --now winesap-zram.service
+
+        qdbus ${kdialog_dbus} /ProgressDialog org.kde.kdialog.ProgressDialog.close
+    fi
 fi
 
 kdialog --title "winesapOS First-Time Setup" --yesno "Do you want to change the current locale (en_US.UTF-8 UTF-8)?"


### PR DESCRIPTION
Defaulted to using half of physical RAM for now (which is probably reasonable)

I think if possible we could change the flow so it sets up zram first instead of swap. This would be useful esp. in case the user actually installs winesap to a USB stick that have limited I/O performance and write cycles.