### PR TITLE
Adding lightdm failsafe

### DIFF
--- a/files/lightdm-failure-handler.service
+++ b/files/lightdm-failure-handler.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Handle LightDM failure
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo -e "Arch Linux \\r (\\l)\n\nLightDM has failed to start. You are now in TTY2 for troubleshooting...\nPossible causes might be a bad Xorg configuration or other graphical issues.\nYou can try to fix the issue here, or reboot the system.\nFor more detailed logs, use \'journalctl -xe | grep lightdm\'." > /etc/issue; /usr/bin/chvt 2'
+
+[Install]
+WantedBy=multi-user.target

--- a/files/lightdm-failure-handler.service
+++ b/files/lightdm-failure-handler.service
@@ -3,7 +3,7 @@ Description=Handle LightDM failure
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'echo -e "Arch Linux \\r (\\l)\n\nLightDM has failed to start. You are now in TTY2 for troubleshooting...\nPossible causes might be a bad Xorg configuration or other graphical issues.\nYou can try to fix the issue here, or reboot the system.\nFor more detailed logs, use \'journalctl -xe | grep lightdm\'." > /etc/issue; /usr/bin/chvt 2'
+ExecStart=/bin/sh -c 'echo -e "Arch Linux \\\\r (\\\\l)\n\nLightDM has failed to start. You are now in a TTY for troubleshooting...\nPossible causes might be a bad Xorg configuration or other graphical issues.\nYou can try to fix the issue here, or reboot the system.\nFor more detailed logs, use \'journalctl -xe | grep lightdm\'." > /etc/issue; /usr/bin/chvt 2'
 
 [Install]
 WantedBy=multi-user.target

--- a/files/lightdm-restart-policy.conf
+++ b/files/lightdm-restart-policy.conf
@@ -1,0 +1,7 @@
+[Unit]
+StartLimitInterval=60s
+StartLimitBurst=3
+OnFailure=lightdm-failure-handler.service
+
+[Service]
+RestartSec=5s

--- a/files/lightdm-success-handler.service
+++ b/files/lightdm-success-handler.service
@@ -5,7 +5,7 @@ After=lightdm.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'echo -e "Arch Linux \\r (\\l)\n\n" > /etc/issue'
+ExecStart=/bin/sh -c 'echo -e "Arch Linux \\\\r (\\\\l)\n\n" > /etc/issue'
 
 [Install]
 WantedBy=graphical.target

--- a/files/lightdm-success-handler.service
+++ b/files/lightdm-success-handler.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reset /etc/issue after LightDM starts successfully
+Requires=lightdm.service
+After=lightdm.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo -e "Arch Linux \\r (\\l)\n\n" > /etc/issue'
+
+[Install]
+WantedBy=graphical.target

--- a/scripts/winesapos-install.sh
+++ b/scripts/winesapos-install.sh
@@ -728,6 +728,13 @@ pacman_install_chroot xorg-server xorg-xinit xorg-xinput xterm xf86-input-libinp
 # Install Light Display Manager.
 pacman_install_chroot lightdm lightdm-gtk-greeter
 yay_install_chroot lightdm-settings
+# Set up lightdm failover handler
+mkdir -p ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/lightdm.service.d
+cp ../files/lightdm-restart-policy.conf ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/lightdm.service.d/
+cp ../files/lightdm-failure-handler.service ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/
+cp ../files/lightdm-success-handler.service ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/
+chroot ${WINESAPOS_INSTALL_DIR} systemctl daemon-reload
+chroot ${WINESAPOS_INSTALL_DIR} systemctl enable lightdm-success-handler
 
 if [[ "${WINESAPOS_AUTO_LOGIN}" == "true" ]]; then
     chroot ${WINESAPOS_INSTALL_DIR} groupadd --system autologin

--- a/scripts/winesapos-install.sh
+++ b/scripts/winesapos-install.sh
@@ -733,7 +733,6 @@ mkdir -p ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/lightdm.service.d
 cp ../files/lightdm-restart-policy.conf ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/lightdm.service.d/
 cp ../files/lightdm-failure-handler.service ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/
 cp ../files/lightdm-success-handler.service ${WINESAPOS_INSTALL_DIR}/etc/systemd/system/
-chroot ${WINESAPOS_INSTALL_DIR} systemctl daemon-reload
 chroot ${WINESAPOS_INSTALL_DIR} systemctl enable lightdm-success-handler
 
 if [[ "${WINESAPOS_AUTO_LOGIN}" == "true" ]]; then


### PR DESCRIPTION
Resolves https://github.com/LukeShortCloud/winesapOS/issues/670

Currently, if there is an issue with lightdm starting xorg, the user experiences a black screen, with no indication of what is happening, and no clear way of breaking out of this to troubleshoot.

These changes will switch a user to TTY2 if lightdm fails to start, and provides a brief message to the user explaining what is happening, and what they might need to investigate.