### PR TITLE
Update legacy StartLimitInterval

### DIFF
--- a/files/sddm-restart-policy.conf
+++ b/files/sddm-restart-policy.conf
@@ -1,5 +1,5 @@
 [Unit]
-StartLimitInterval=60s
+StartLimitIntervalSec=60s
 StartLimitBurst=3
 OnFailure=sddm-failure-handler.service
 


### PR DESCRIPTION
When I initially made these changes, I had some trouble finding good details on `StartLimitInterval` vs `StartLimitIntervalSec`, and when/where to use it. I had a hunch that I had used the legacy syntax here, but I was able to actually confirm it just now from details in this PR https://github.com/systemd/systemd/issues/16644